### PR TITLE
quick fix: workaround for unexpected dropouts during part downloads

### DIFF
--- a/src/ADLCore/Video/VidStream.nim
+++ b/src/ADLCore/Video/VidStream.nim
@@ -207,7 +207,16 @@ proc DownloadNextVideoPart(this: Video, path: string): bool {.nimcall.} =
     file = open(path, fmAppend)
   else:
     file = open(path, fmWrite)
-  let videoData = this.ourClient.getContent(this.videoStream[this.videoCurrIdx])
+  var aLock: bool = true
+  var counter: int = 0
+  var videoData: string = ""
+  while aLock and counter < 10:
+    try:
+      videoData = this.ourClient.getContent(this.videoStream[this.videoCurrIdx])
+      aLock = false
+    except:
+      inc counter
+      echo "Failed Download, Retrying $1/$2" % [$counter, "10"]
   write(file, videoData)
   inc this.videoCurrIdx
   close(file)


### PR DESCRIPTION
Not perfect, line not cleared, will fix either. Rushing to push this out for 3.0.4 animedl, since a problem in the windows version has appeared. Windows exe needs to ship with openssl libs and a cert.